### PR TITLE
Add property tests

### DIFF
--- a/calendrical/calendrical.cabal
+++ b/calendrical/calendrical.cabal
@@ -271,3 +271,20 @@ test-suite csv-data
     Paths_calendrical
   autogen-modules:
     Paths_calendrical
+
+test-suite properties
+  import: defaults
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    tests
+  main-is: properties.hs
+  build-depends:
+    calendrical,
+    hedgehog ^>= {1.1, 1.2, 1.4, 1.5, 1.7},
+    tasty ^>= {1.1.0, 1.4.2, 1.5.3},
+    tasty-hedgehog ^>= {1.1.0, 1.3.0, 1.4.0},
+  ghc-options:
+    -O2
+  other-modules:
+    Properties.Calendars
+    Properties.Class

--- a/calendrical/src/Data/Calendar.hs
+++ b/calendrical/src/Data/Calendar.hs
@@ -51,7 +51,7 @@ module Data.Calendar
     -- * mod
     Mod (..),
     modI,
-    mod1,
+    amod,
   )
 where
 
@@ -90,10 +90,10 @@ import "this" Data.Calendar.Types
     NonegativeReal,
     PositiveReal,
     Real,
+    amod,
     binarySearch,
     deg,
     mod,
-    mod1,
     modI,
     modularToEnum,
   )

--- a/calendrical/src/Data/Calendar.hs
+++ b/calendrical/src/Data/Calendar.hs
@@ -11,8 +11,8 @@
 -- Copyright: 2024 Greg Pfeil
 -- License: AGPL-3.0-only WITH Universal-FOSS-exception-1.0 OR LicenseRef-commercial
 module Data.Calendar
-  ( Calendar,
-    CyclicCalendar,
+  ( LinearCalendar,
+    Calendar,
     DayOfWeek (Friday, Monday, Saturday, Sunday, Thursday, Tuesday, Wednesday),
     Interval,
     JulianDayNumber (JD),
@@ -146,13 +146,13 @@ type IsoDateTime =
        Nat.FromGHC 60 -- second
      ]
 
--- | A `CyclicCalendar` doesn’t assign _unique_ names to dates, but can map
+-- | A `Calendar` doesn’t assign _unique_ names to dates, but can map
 --   multiple dates to the same name. A simple example is `DayOfWeek`, which
 --   maps all dates to one of @`Sunday` .. `Saturday`@.
 --
 -- -prop> let date = fromFixed rd' in rd' `elem` fixedsFrom date
-type CyclicCalendar :: Type -> Constraint
-class CyclicCalendar date where
+type Calendar :: Type -> Constraint
+class Calendar date where
   type RD date :: Type
   type RD _ = FixedDate
 
@@ -174,13 +174,13 @@ class CyclicCalendar date where
   fromFixed = fromMoment . momentFrom
 
   -- | This returns either exactly one or an infinite number of `FixedDate`s. The
-  --   distinction is whether @date@ also implements `Calendar`, in which case
+  --   distinction is whether @date@ also implements `LinearCalendar`, in which case
   --   this must return a single value.
   --
   --   This returns values ordered by distance from @`RD` 0@. (Or is it distance
   --   from @`epoch` (`Proxy` :: `Proxy` date)@?)
   fixedsFrom :: date -> NonEmpty FixedDate
-  default fixedsFrom :: (Calendar date) => date -> NonEmpty FixedDate
+  default fixedsFrom :: (LinearCalendar date) => date -> NonEmpty FixedDate
   fixedsFrom = pure . fixedFrom
 
   fromMoment :: Moment -> date
@@ -194,8 +194,8 @@ class CyclicCalendar date where
 --            calendars, and some calendars are “cyclic”, where an RD becomes a
 --            single “date”, but a “date” is a possibly infinite list of RDs (or
 --            moments).
-type Calendar :: Type -> Constraint
-class (CyclicCalendar date, Ord date) => Calendar date where
+type LinearCalendar :: Type -> Constraint
+class (Calendar date, Ord date) => LinearCalendar date where
   -- | I thisk these two form an isomorphism
   fixedFrom :: date -> FixedDate
   fixedFrom = fixedFromMoment . momentFrom
@@ -205,15 +205,15 @@ class (CyclicCalendar date, Ord date) => Calendar date where
   momentFrom :: date -> Moment
   momentFrom = momentFrom . fixedFrom
 
-validDate :: (Calendar date) => date -> Bool
+validDate :: (LinearCalendar date) => date -> Bool
 validDate date = date == fromFixed (fixedFrom date)
 
-instance CyclicCalendar FixedDate where
+instance Calendar FixedDate where
   epoch _ = RD 0
   fromFixed date = RD . dayNumberFromFixed date . epoch $ Identity date
   fromMoment = fixedFromMoment
 
-instance Calendar FixedDate where
+instance LinearCalendar FixedDate where
   fixedFrom date = fixedFromInteger (offset date) . epoch $ Identity date
   momentFrom = Moment . rationalize . offset
 
@@ -221,7 +221,7 @@ type JulianDayNumber :: Type
 newtype JulianDayNumber = JD {dayNumber :: Real}
   deriving stock (Eq, Ord, Read, Show)
 
-instance CyclicCalendar JulianDayNumber where
+instance Calendar JulianDayNumber where
   type RD JulianDayNumber = Moment
 
   -- (1.3)
@@ -230,11 +230,11 @@ instance CyclicCalendar JulianDayNumber where
   -- (1.5)
   fromMoment t = JD . momentToReal $ t - epoch (Proxy :: Proxy JulianDayNumber)
 
-instance Calendar JulianDayNumber where
+instance LinearCalendar JulianDayNumber where
   -- (1.4)
   momentFrom jd = Moment (dayNumber jd) + epoch (Identity jd)
 
-jd :: (Calendar date) => Integer -> date
+jd :: (LinearCalendar date) => Integer -> date
 jd n = fromFixed . RD $ n - 1721425
 
 -- | (1.12)
@@ -330,31 +330,31 @@ timeFromClock = (widen (1 % (24 :: Natural)) *) . MixedRadix.eval
 clockFromMoment :: Moment -> Either MixedRadix.FloatFailure ClockTime
 clockFromMoment (Moment t) = MixedRadix.interpret . snd $ mixedFraction t
 
--- instance CyclicCalendar Hebrew where
+-- instance Calendar Hebrew where
 --   epoch _ = RD -1373427
 
--- instance CyclicCalendar Mayan where
+-- instance Calendar Mayan where
 --   epoch _ = RD -1137142
 
--- instance CyclicCalendar Chinese where
+-- instance Calendar Chinese where
 --   epoch _ = RD -963099
 
--- instance CyclicCalendar Samaritan where
+-- instance Calendar Samaritan where
 --   epoch _ = RD -598573
 
--- instance CyclicCalendar Babylonian where
+-- instance Calendar Babylonian where
 --   epoch _ = RD -113502
 
--- instance CyclicCalendar Tibetan where
+-- instance Calendar Tibetan where
 --   epoch _ = RD -46410
 
--- instance CyclicCalendar ISO where
+-- instance Calendar ISO where
 --   epoch _ = RD 1
 
--- instance CyclicCalendar Persian where
+-- instance Calendar Persian where
 --   epoch _ = RD 226896
 
--- instance CyclicCalendar Islamic where
+-- instance Calendar Islamic where
 --   epoch _ = RD 227015
 
 type DayOfWeek :: Type
@@ -395,7 +395,7 @@ instance Enum DayOfWeek where
 
 instance ModularEnum DayOfWeek
 
-instance CyclicCalendar DayOfWeek where
+instance Calendar DayOfWeek where
   epoch _ = RD 0
 
   -- (1.60)
@@ -448,23 +448,23 @@ kdayBefore k date = kdayOnOrBefore k $ date - 1
 kdayAfter :: DayOfWeek -> FixedDate -> FixedDate
 kdayAfter k = kdayOnOrBefore k . (+ 7)
 
--- instance CyclicCalendar FrenchRevolutionary where
+-- instance Calendar FrenchRevolutionary where
 --   epoch _ = RD 654415
 
--- instance CyclicCalendar Baha'i where
+-- instance Calendar Baha'i where
 --   epoch _ = RD 673222
 
 type ModifiedJulianDayNumber :: Type
 newtype ModifiedJulianDayNumber = MJD Integer
   deriving stock (Eq, Ord, Read, Show)
 
-instance CyclicCalendar ModifiedJulianDayNumber where
+instance Calendar ModifiedJulianDayNumber where
   epoch _ = RD 678576
   fromFixed (RD date) =
     MJD $ date - offset (epoch (Proxy :: Proxy ModifiedJulianDayNumber))
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar ModifiedJulianDayNumber where
+instance LinearCalendar ModifiedJulianDayNumber where
   fixedFrom (MJD mjd) =
     RD $ mjd + offset (epoch (Proxy :: Proxy ModifiedJulianDayNumber))
 
@@ -472,12 +472,12 @@ type Unix :: Type
 newtype Unix = SecondsSinceUnixEpoch Second
   deriving stock (Eq, Ord, Read, Show)
 
-instance CyclicCalendar Unix where
+instance Calendar Unix where
   epoch _ = RD 719163
   fromMoment (Moment t) =
     SecondsSinceUnixEpoch $
       24 * 60 * 60 * (t - fromIntegral (offset $ epoch (Proxy :: Proxy Unix)))
 
-instance Calendar Unix where
+instance LinearCalendar Unix where
   momentFrom (SecondsSinceUnixEpoch s) =
     momentFrom (epoch (Proxy :: Proxy Unix)) + Moment (s % 24 % 60 % 60)

--- a/calendrical/src/Data/Calendar.hs
+++ b/calendrical/src/Data/Calendar.hs
@@ -50,7 +50,7 @@ module Data.Calendar
 
     -- * mod
     Mod (..),
-    modI,
+    mod3,
     amod,
   )
 where
@@ -94,7 +94,7 @@ import "this" Data.Calendar.Types
     binarySearch,
     deg,
     mod,
-    modI,
+    mod3,
     modularToEnum,
   )
 import "base" Prelude
@@ -314,7 +314,7 @@ positionsInRange p c δ (a, b) =
     else date : positionsInRange p c δ (interval next b)
   where
     next = a + Moment (widen c)
-    date = Moment (widen $ p - δ) `modI` interval a next
+    date = Moment (widen $ p - δ) `mod3` interval a next
 
 type Range :: Type
 type Range = (FixedDate, FixedDate)

--- a/calendrical/src/Data/Calendar.hs
+++ b/calendrical/src/Data/Calendar.hs
@@ -13,6 +13,7 @@
 module Data.Calendar
   ( LinearCalendar,
     Calendar,
+    CyclicCalendar,
     DayOfWeek (Friday, Monday, Saturday, Sunday, Thursday, Tuesday, Wednesday),
     Interval,
     JulianDayNumber (JD),
@@ -37,11 +38,11 @@ module Data.Calendar
     kdayBefore,
     kdayNearest,
     kdayOnOrAfter,
-    kdayOnOrBefore,
     listRange,
     momentFrom,
     momentToReal,
     offset,
+    onOrBefore,
     positionsInRange,
     timeFromClock,
     timeFromMoment,
@@ -150,6 +151,9 @@ type IsoDateTime =
 --   multiple dates to the same name. A simple example is `DayOfWeek`, which
 --   maps all dates to one of @`Sunday` .. `Saturday`@.
 --
+--  __NOTE__: Every `Calendar` should implement one of either `CyclicCalendar`
+--            or `LinearCalendar`.
+--
 -- -prop> let date = fromFixed rd' in rd' `elem` fixedsFrom date
 type Calendar :: Type -> Constraint
 class Calendar date where
@@ -184,6 +188,14 @@ class Calendar date where
   fixedsFrom = pure . fixedFrom
 
   fromMoment :: Moment -> date
+
+-- | A `Calendar` whose date space wraps around in a cycle, so a given @date@
+--   maps to infinitely many `FixedDate`s.
+type CyclicCalendar :: Type -> Constraint
+class (Calendar date) => CyclicCalendar date where
+  -- | The latest `FixedDate` on or before the given one whose `fromFixed`
+  --   projection equals @date@.
+  onOrBefore :: date -> FixedDate -> FixedDate
 
 -- |
 --
@@ -425,28 +437,29 @@ type StandardDay = Fin (Nat.FromGHC 32)
 type StandardYear :: Type
 type StandardYear = Integer
 
-kdayOnOrBefore :: DayOfWeek -> FixedDate -> FixedDate
-kdayOnOrBefore k (RD date) =
-  RD $
-    date
-      - widen
-        (fromEnum @DayOfWeek . fromFixed . RD $ date - widen (fromEnum k))
+instance CyclicCalendar DayOfWeek where
+  -- Fixed date of the @k@-day on or before fixed @date@.
+  onOrBefore k (RD date) =
+    RD $
+      date
+        - widen
+          (fromEnum @DayOfWeek . fromFixed . RD $ date - widen (fromEnum k))
 
 kdayOnOrAfter :: DayOfWeek -> FixedDate -> FixedDate
-kdayOnOrAfter k = kdayOnOrBefore k . (+ 6)
+kdayOnOrAfter k = onOrBefore k . (+ 6)
 
 kdayNearest :: DayOfWeek -> FixedDate -> FixedDate
-kdayNearest k = kdayOnOrBefore k . (+ 3)
+kdayNearest k = onOrBefore k . (+ 3)
 
 -- | Fixed date of the @k@-day before fixed @date@. @k@=0 means Sunday, @k@=1
 --   means Monday, and so on.
 kdayBefore :: DayOfWeek -> FixedDate -> FixedDate
-kdayBefore k date = kdayOnOrBefore k $ date - 1
+kdayBefore k date = onOrBefore k $ date - 1
 
 -- | Fixed date of the @k@-day after fixed @date@. @k@=0 means Sunday, @k@=1
 --   means Monday, and so on.
 kdayAfter :: DayOfWeek -> FixedDate -> FixedDate
-kdayAfter k = kdayOnOrBefore k . (+ 7)
+kdayAfter k = onOrBefore k . (+ 7)
 
 -- instance Calendar FrenchRevolutionary where
 --   epoch _ = RD 654415

--- a/calendrical/src/Data/Calendar/Akan.hs
+++ b/calendrical/src/Data/Calendar/Akan.hs
@@ -8,7 +8,6 @@ module Data.Calendar.Akan
   ( Name (Name),
     Prefix (Fo, Kuru, Kwa, Mono, Nkyi, Nwona),
     Stem (Bene, Dwo, Fie, Kwasi, Memene, Wukuo, Yaw),
-    dayNameOnOrBefore,
     nameDifference,
     prefix,
     stem,
@@ -28,6 +27,7 @@ import "base" Text.Read (Read)
 import "base" Text.Show (Show)
 import "this" Data.Calendar
   ( Calendar,
+    CyclicCalendar,
     FixedDate (RD),
     Moment (Moment),
     epoch,
@@ -37,6 +37,7 @@ import "this" Data.Calendar
     mod1,
     modI,
     offset,
+    onOrBefore,
   )
 import "this" Data.Calendar.Types (ModularEnum, modularToEnum)
 import "base" Prelude
@@ -132,7 +133,7 @@ instance Calendar Name where
   fromFixed (RD date) = dayName (date - offset (epoch (Proxy :: Proxy Name)))
   fromMoment (Moment t) = fromFixed . RD $ floor t
   fixedsFrom name =
-    let origin = dayNameOnOrBefore name . epoch $ Identity name
+    let origin = onOrBefore name . epoch $ Identity name
      in origin
           :| ( ( \cycle ->
                    let days = 42 * cycle in [origin - days, origin + days]
@@ -140,6 +141,7 @@ instance Calendar Name where
                  =<< [1 ..]
              )
 
-dayNameOnOrBefore :: Name -> FixedDate -> FixedDate
-dayNameOnOrBefore name (RD date) =
-  RD $ nameDifference (fromFixed $ RD 0) name `modI` (date, date - 42)
+instance CyclicCalendar Name where
+  -- Fixed date of latest date on or before fixed @date@ that has Akan @name@.
+  onOrBefore name (RD date) =
+    RD $ nameDifference (fromFixed $ RD 0) name `modI` (date, date - 42)

--- a/calendrical/src/Data/Calendar/Akan.hs
+++ b/calendrical/src/Data/Calendar/Akan.hs
@@ -27,7 +27,7 @@ import "base" Data.Proxy (Proxy (Proxy))
 import "base" Text.Read (Read)
 import "base" Text.Show (Show)
 import "this" Data.Calendar
-  ( CyclicCalendar,
+  ( Calendar,
     FixedDate (RD),
     Moment (Moment),
     epoch,
@@ -127,7 +127,7 @@ nameDifference day1 day2 =
     prefixDifference = fromIntegral $ fromEnum (prefix day2) - fromEnum (prefix day1)
     stemDifference = fromIntegral $ fromEnum (stem day2) - fromEnum (stem day1)
 
-instance CyclicCalendar Name where
+instance Calendar Name where
   epoch _ = RD 37
   fromFixed (RD date) = dayName (date - offset (epoch (Proxy :: Proxy Name)))
   fromMoment (Moment t) = fromFixed . RD $ floor t

--- a/calendrical/src/Data/Calendar/Akan.hs
+++ b/calendrical/src/Data/Calendar/Akan.hs
@@ -30,11 +30,11 @@ import "this" Data.Calendar
     CyclicCalendar,
     FixedDate (RD),
     Moment (Moment),
+    amod,
     epoch,
     fixedsFrom,
     fromFixed,
     fromMoment,
-    mod1,
     modI,
     offset,
     onOrBefore,
@@ -118,12 +118,12 @@ data Name = Name {prefix :: Prefix, stem :: Stem}
 
 dayName :: Integer -> Name
 dayName n =
-  Name (toEnum . fromIntegral $ n `mod1` 6) . toEnum . fromIntegral $
-    n `mod1` 7
+  Name (toEnum . fromIntegral $ n `amod` 6) . toEnum . fromIntegral $
+    n `amod` 7
 
 nameDifference :: Name -> Name -> Integer
 nameDifference day1 day2 =
-  prefixDifference + 36 * (stemDifference - prefixDifference) `mod1` 42
+  prefixDifference + 36 * (stemDifference - prefixDifference) `amod` 42
   where
     prefixDifference = fromIntegral $ fromEnum (prefix day2) - fromEnum (prefix day1)
     stemDifference = fromIntegral $ fromEnum (stem day2) - fromEnum (stem day1)

--- a/calendrical/src/Data/Calendar/Akan.hs
+++ b/calendrical/src/Data/Calendar/Akan.hs
@@ -35,7 +35,7 @@ import "this" Data.Calendar
     fixedsFrom,
     fromFixed,
     fromMoment,
-    modI,
+    mod3,
     offset,
     onOrBefore,
   )
@@ -144,4 +144,4 @@ instance Calendar Name where
 instance CyclicCalendar Name where
   -- Fixed date of latest date on or before fixed @date@ that has Akan @name@.
   onOrBefore name (RD date) =
-    RD $ nameDifference (fromFixed $ RD 0) name `modI` (date, date - 42)
+    RD $ nameDifference (fromFixed $ RD 0) name `mod3` (date, date - 42)

--- a/calendrical/src/Data/Calendar/Armenian.hs
+++ b/calendrical/src/Data/Calendar/Armenian.hs
@@ -18,8 +18,8 @@ import "base" Text.Read (Read)
 import "base" Text.Show (Show)
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
     FixedDate (RD),
+    LinearCalendar,
     epoch,
     fixedFrom,
     fromFixed,
@@ -55,10 +55,10 @@ type Date = T30P5.Date Month
 ops :: T30P5.Operations Month
 ops = T30P5.operationsForEpoch $ RD 201443
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = T30P5.epoch ops
   fromFixed = T30P5.fromFixed ops
   fromMoment = T30P5.fromMoment ops
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom = T30P5.fixedFrom ops

--- a/calendrical/src/Data/Calendar/Coptic.hs
+++ b/calendrical/src/Data/Calendar/Coptic.hs
@@ -25,8 +25,8 @@ import "base" Text.Read (Read)
 import "base" Text.Show (Show)
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
     FixedDate,
+    LinearCalendar,
     epoch,
     fixedFrom,
     fromFixed,
@@ -73,12 +73,12 @@ ops =
   T30P5.operationsForEpoch . fixedFrom $
     Julian.Date (Julian.CE 284) Julian.August 29
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = T30P5.epoch ops
   fromFixed = T30P5.fromFixed ops
   fromMoment = T30P5.fromMoment ops
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom = T30P5.fixedFrom ops
 
 -- |

--- a/calendrical/src/Data/Calendar/Egyptian.hs
+++ b/calendrical/src/Data/Calendar/Egyptian.hs
@@ -19,8 +19,8 @@ import "base" Text.Read (Read)
 import "base" Text.Show (Show)
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
     JulianDayNumber (JD),
+    LinearCalendar,
     epoch,
     fixedFrom,
     fromFixed,
@@ -53,10 +53,10 @@ type Date = T30P5.Date Month
 ops :: T30P5.Operations Month
 ops = T30P5.operationsForEpoch . fixedFrom $ JD 1448638
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = T30P5.epoch ops
   fromFixed = T30P5.fromFixed ops
   fromMoment = T30P5.fromMoment ops
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom = T30P5.fixedFrom ops

--- a/calendrical/src/Data/Calendar/Ethiopic.hs
+++ b/calendrical/src/Data/Calendar/Ethiopic.hs
@@ -19,7 +19,7 @@ import "base" Text.Read (Read)
 import "base" Text.Show (Show)
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
+    LinearCalendar,
     epoch,
     fixedFrom,
     fromFixed,
@@ -63,10 +63,10 @@ ops =
   T30P5.operationsForEpoch . fixedFrom $
     Julian.Date (Julian.CE 8) Julian.August 29
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = T30P5.epoch ops
   fromFixed = T30P5.fromFixed ops
   fromMoment = T30P5.fromMoment ops
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom = T30P5.fixedFrom ops

--- a/calendrical/src/Data/Calendar/Gregorian.hs
+++ b/calendrical/src/Data/Calendar/Gregorian.hs
@@ -61,8 +61,8 @@ import "fin" Data.Type.Nat qualified as Nat
 import "numeric-tangle" Numeric.Widen (widen)
 import "numeric-tangle-fin" Numeric.Widen.Instances.Fin ()
 import "this" Data.Calendar
-  ( Calendar,
-    CyclicCalendar,
+  ( LinearCalendar,
+    Calendar,
     DayOfWeek (Friday, Monday, Sunday, Tuesday),
     FixedDate (RD),
     Moment (Moment),
@@ -157,7 +157,7 @@ data Date = Date
   {year :: Year, month :: Month, day :: Day}
   deriving stock (Eq, Ord, Show)
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = RD 1
   fromFixed date = Date {year, month, day}
     where
@@ -172,7 +172,7 @@ instance CyclicCalendar Date where
       day = fromIntegral . offset $ date - fixedFrom (Date year month 1) + 1
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom Date {year, month, day} =
     RD $
       offset (epoch (Proxy :: Proxy Date))

--- a/calendrical/src/Data/Calendar/Gregorian.hs
+++ b/calendrical/src/Data/Calendar/Gregorian.hs
@@ -61,12 +61,13 @@ import "fin" Data.Type.Nat qualified as Nat
 import "numeric-tangle" Numeric.Widen (widen)
 import "numeric-tangle-fin" Numeric.Widen.Instances.Fin ()
 import "this" Data.Calendar
-  ( LinearCalendar,
-    Calendar,
+  ( Calendar,
     DayOfWeek (Friday, Monday, Sunday, Tuesday),
     FixedDate (RD),
+    LinearCalendar,
     Moment (Moment),
     Range,
+    amod,
     epoch,
     fixedFrom,
     fromFixed,
@@ -76,7 +77,6 @@ import "this" Data.Calendar
     kdayNearest,
     kdayOnOrAfter,
     mod,
-    mod1,
     offset,
   )
 import "this" Data.Calendar.Types
@@ -236,7 +236,7 @@ lastDayOfMonth gYear gMonth =
   fromIntegral . dateDifference (Date gYear gMonth 1) $
     Date
       (if gMonth == December then gYear + 1 else gYear)
-      (toEnum $ fromEnum gMonth + 1 `mod1` 12)
+      (toEnum $ fromEnum gMonth + 1 `amod` 12)
       1
 
 independenceDay :: Year -> FixedDate

--- a/calendrical/src/Data/Calendar/Hindu/Old/Lunar.hs
+++ b/calendrical/src/Data/Calendar/Hindu/Old/Lunar.hs
@@ -35,8 +35,8 @@ import "numeric-tangle" Numeric.Ration (rationalize, (%))
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
     FixedDate (RD),
+    LinearCalendar,
     Moment (Moment),
     epoch,
     fixedFrom,
@@ -148,7 +148,7 @@ isLeapYear lYear =
   (rationalize lYear * Solar.aryaYear - Solar.aryaMonth) `mod` aryaMonth
     >= widen ((23902504679 :: Natural) % 1282400064)
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = Hindu.epoch
   fromFixed date = Date {year, month, leap, day}
     where
@@ -162,7 +162,7 @@ instance CyclicCalendar Date where
       year = ceiling ((newMoon + Solar.aryaMonth) % Solar.aryaYear) - 1
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom Date {year, month, leap, day} =
     RD . ceiling $
       rationalize (offset $ epoch (Proxy :: Proxy Date))

--- a/calendrical/src/Data/Calendar/Hindu/Old/Lunar.hs
+++ b/calendrical/src/Data/Calendar/Hindu/Old/Lunar.hs
@@ -168,18 +168,19 @@ instance LinearCalendar Date where
       rationalize (offset $ epoch (Proxy :: Proxy Date))
         + newYear
         + aryaMonth
-          * ( widen . rationalize . fromEnum $
+          * ( widen . rationalize $
                 if not leap
                   && fromIntegral
                     ( ceiling $
                         (newYear - mina) % (Solar.aryaMonth - aryaMonth)
                     )
-                    <= fromEnum month
-                  then month
-                  else pred month
+                    <= monthIx
+                  then monthIx
+                  else pred monthIx
             )
         + rationalize (widen @_ @Integer day - 1) * aryaDay
         + hr (-6)
     where
+      monthIx = fromEnum month
       mina = (12 * rationalize year - 1) * Solar.aryaMonth
       newYear = aryaMonth * rationalize (quotient mina aryaMonth + 1)

--- a/calendrical/src/Data/Calendar/Hindu/Old/Solar.hs
+++ b/calendrical/src/Data/Calendar/Hindu/Old/Solar.hs
@@ -32,8 +32,8 @@ import "numeric-tangle" Numeric.Ration (rationalize, (%))
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
     FixedDate (RD),
+    LinearCalendar,
     Moment (Moment),
     epoch,
     fixedFrom,
@@ -175,7 +175,7 @@ type Date :: Type
 data Date = Date {year :: Year, month :: Month, day :: Day}
   deriving stock (Eq, Ord, Show)
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = Hindu.epoch
   fromFixed date = Date {year, month, day}
     where
@@ -185,7 +185,7 @@ instance CyclicCalendar Date where
       day = floor (sun `mod` aryaMonth) + 1
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom Date {year, month, day} =
     RD . ceiling $
       rationalize (offset $ epoch (Proxy :: Proxy Date)) -- Since start of era.

--- a/calendrical/src/Data/Calendar/Icelandic.hs
+++ b/calendrical/src/Data/Calendar/Icelandic.hs
@@ -40,9 +40,9 @@ import "numeric-tangle" Numeric.Widen (widen)
 import "numeric-tangle-fin" Numeric.Widen.Instances.Fin ()
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
     DayOfWeek (Saturday, Thursday),
     FixedDate (RD),
+    LinearCalendar,
     Moment (Moment),
     epoch,
     fixedFrom,
@@ -107,7 +107,7 @@ summer iYear =
 winter :: Year -> FixedDate
 winter iYear = summer (iYear + 1) - 180
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = fixedFrom $ Gregorian.Date 1 Gregorian.April 19
   fromFixed date =
     let approx =
@@ -125,7 +125,7 @@ instance CyclicCalendar Date where
           }
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom Date {year, season, week, weekday} =
     start
       + RD (7 * (widen week - 1))

--- a/calendrical/src/Data/Calendar/Islamic.hs
+++ b/calendrical/src/Data/Calendar/Islamic.hs
@@ -33,8 +33,8 @@ import "fin" Data.Type.Nat qualified as Nat
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
     FixedDate (RD),
+    LinearCalendar,
     Moment (Moment),
     epoch,
     fixedFrom,
@@ -120,7 +120,7 @@ type Date :: Type
 data Date = Date {year :: Year, month :: Month, day :: Day}
   deriving stock (Eq, Ord, Show)
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = fixedFrom $ Julian.Date (Julian.CE 622) Julian.July 16
   fromFixed date =
     let year = (30 * offset (date - epoch (Proxy :: Proxy Date)) + 10646) `div` 10631
@@ -134,7 +134,7 @@ instance CyclicCalendar Date where
           }
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom Date {year, month, day} =
     RD $
       offset (epoch (Proxy :: Proxy Date))

--- a/calendrical/src/Data/Calendar/Iso.hs
+++ b/calendrical/src/Data/Calendar/Iso.hs
@@ -26,16 +26,16 @@ import "fin" Data.Fin (Fin)
 import "fin" Data.Type.Nat qualified as Nat
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
-  ( LinearCalendar,
-    Calendar,
+  ( Calendar,
     DayOfWeek (Sunday, Thursday),
     FixedDate (RD),
+    LinearCalendar,
     Moment (Moment),
+    amod,
     epoch,
     fixedFrom,
     fromFixed,
     fromMoment,
-    mod1,
     offset,
   )
 import "this" Data.Calendar.Gregorian (Year)
@@ -64,7 +64,7 @@ instance Calendar Date where
       week =
         fromIntegral $
           offset (date - fixedFrom (Date year 1 1)) `div` 7 + 1
-      day = toEnum . fromIntegral $ offset (date - RD 0) `mod1` 7
+      day = toEnum . fromIntegral $ offset (date - RD 0) `amod` 7
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
 instance LinearCalendar Date where

--- a/calendrical/src/Data/Calendar/Iso.hs
+++ b/calendrical/src/Data/Calendar/Iso.hs
@@ -26,8 +26,8 @@ import "fin" Data.Fin (Fin)
 import "fin" Data.Type.Nat qualified as Nat
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
-  ( Calendar,
-    CyclicCalendar,
+  ( LinearCalendar,
+    Calendar,
     DayOfWeek (Sunday, Thursday),
     FixedDate (RD),
     Moment (Moment),
@@ -52,7 +52,7 @@ type Date :: Type
 data Date = Date {year :: Year, week :: Week, day :: Day}
   deriving stock (Eq, Ord, Show)
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = epoch (Proxy :: Proxy Gregorian.Date)
   fromFixed date = Date {year, week, day}
     where
@@ -67,7 +67,7 @@ instance CyclicCalendar Date where
       day = toEnum . fromIntegral $ offset (date - RD 0) `mod1` 7
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom Date {year, week, day} =
     Gregorian.nthKday
       (widen week)

--- a/calendrical/src/Data/Calendar/Julian.hs
+++ b/calendrical/src/Data/Calendar/Julian.hs
@@ -48,8 +48,8 @@ import "numeric-tangle" Numeric.Abs (splitAbs)
 import "numeric-tangle" Numeric.Chop (floor)
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
-  ( Calendar,
-    CyclicCalendar,
+  ( LinearCalendar,
+    Calendar,
     FixedDate (RD),
     Moment (Moment),
     epoch,
@@ -121,7 +121,7 @@ type Date :: Type
 data Date = Date {year :: Year, month :: Month, day :: Day}
   deriving stock (Eq, Ord, Show)
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = RD (-1)
   fromFixed date = Date year month day
     where
@@ -137,7 +137,7 @@ instance CyclicCalendar Date where
       day = fromIntegral (offset $ date - fixedFrom (Date year month 1)) + 1
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom Date {year, month, day} =
     RD $
       offset (epoch (Proxy :: Proxy Date))
@@ -177,7 +177,7 @@ data RomanDate = RomanDate
   }
   deriving stock (Eq, Ord, Show)
 
-instance CyclicCalendar RomanDate where
+instance Calendar RomanDate where
   epoch _ = epoch (Proxy :: Proxy Date)
   fromFixed date
     | day == 1 = RomanDate year month Kalends 1 False
@@ -217,7 +217,7 @@ instance CyclicCalendar RomanDate where
       kalends1 = fixedFrom $ RomanDate year' month' Kalends 1 False
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar RomanDate where
+instance LinearCalendar RomanDate where
   fixedFrom RomanDate {yearR, monthR, event, count, leap} =
     ( case event of
         Kalends -> fixedFrom $ Date yearR monthR 1

--- a/calendrical/src/Data/Calendar/Julian.hs
+++ b/calendrical/src/Data/Calendar/Julian.hs
@@ -48,17 +48,17 @@ import "numeric-tangle" Numeric.Abs (splitAbs)
 import "numeric-tangle" Numeric.Chop (floor)
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
-  ( LinearCalendar,
-    Calendar,
+  ( Calendar,
     FixedDate (RD),
+    LinearCalendar,
     Moment (Moment),
+    amod,
     epoch,
     fixedFrom,
     fromFixed,
     fromMoment,
     listRange,
     mod,
-    mod1,
     momentFrom,
     offset,
   )
@@ -206,7 +206,7 @@ instance Calendar RomanDate where
     | True = RomanDate year March Kalends (fromIntegral $ 31 - day) $ day == 25
     where
       Date {year, month, day} = fromFixed date
-      month' = toEnum $ fromEnum month + 1 `mod1` 12
+      month' = toEnum $ fromEnum month + 1 `amod` 12
       year' =
         if month' /= January
           then year

--- a/calendrical/src/Data/Calendar/Mayan/Haab.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Haab.hs
@@ -15,7 +15,6 @@ module Data.Calendar.Mayan.Haab
     Day,
     day,
     month,
-    onOrBefore,
     ordinal,
     --  FIXME: Don’t eexport
     finMod,
@@ -42,6 +41,7 @@ import "numeric-tangle-fin" Numeric.Ration.Instances.Fin ()
 import "numeric-tangle-fin" Numeric.Widen.Instances.Fin ()
 import "this" Data.Calendar
   ( Calendar,
+    CyclicCalendar,
     FixedDate (RD),
     Moment (Moment),
     epoch,
@@ -49,6 +49,7 @@ import "this" Data.Calendar
     fromFixed,
     fromMoment,
     offset,
+    onOrBefore,
   )
 import "this" Data.Calendar.Mayan qualified as Mayan
 import "this" Data.Calendar.Types
@@ -215,8 +216,8 @@ instance Calendar Date where
 --   @haab@.
 --
 --  (11.7)
-onOrBefore :: Date -> FixedDate -> FixedDate
-onOrBefore haab (RD date) =
-  RD $
-    widen (ordinal haab)
-      + offset (epoch (Proxy :: Proxy Date)) `modI` (date, date - 365)
+instance CyclicCalendar Date where
+  onOrBefore haab (RD date) =
+    RD $
+      widen (ordinal haab)
+        + offset (epoch (Proxy :: Proxy Date)) `modI` (date, date - 365)

--- a/calendrical/src/Data/Calendar/Mayan/Haab.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Haab.hs
@@ -56,7 +56,7 @@ import "this" Data.Calendar.Types
   ( ModularEnum,
     NonnegativeInteger,
     mod,
-    modI,
+    mod3,
     modularToEnum,
     toModularEnum,
   )
@@ -220,4 +220,4 @@ instance CyclicCalendar Date where
   onOrBefore haab (RD date) =
     RD $
       widen (ordinal haab)
-        + offset (epoch (Proxy :: Proxy Date)) `modI` (date, date - 365)
+        + offset (epoch (Proxy :: Proxy Date)) `mod3` (date, date - 365)

--- a/calendrical/src/Data/Calendar/Mayan/Haab.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Haab.hs
@@ -41,7 +41,7 @@ import "numeric-tangle" Numeric.Widen (widen)
 import "numeric-tangle-fin" Numeric.Ration.Instances.Fin ()
 import "numeric-tangle-fin" Numeric.Widen.Instances.Fin ()
 import "this" Data.Calendar
-  ( CyclicCalendar,
+  ( Calendar,
     FixedDate (RD),
     Moment (Moment),
     epoch,
@@ -185,7 +185,7 @@ ordinal Date {month, day} = (fromIntegral (fromEnum month) - 1) * 20 + widen day
 finMod :: forall n m i. (Integral i, SNatI n, n ~ 'S m) => i -> Fin n
 finMod = fromIntegral
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   -- Fixed date of start of haab cycle.
   --
   -- (11.5)

--- a/calendrical/src/Data/Calendar/Mayan/LongCount.hs
+++ b/calendrical/src/Data/Calendar/Mayan/LongCount.hs
@@ -25,8 +25,8 @@ import "mixed-radix" Numeric.MixedRadix (MixedIntegral (IntRadix, Unbounded), ev
 import "numeric-tangle-fin" Numeric.Widen.Instances.Fin ()
 import "this" Data.Calendar
   ( Calendar,
-    CyclicCalendar,
     FixedDate (RD),
+    LinearCalendar,
     Moment (Moment),
     epoch,
     fixedFrom,
@@ -54,14 +54,14 @@ newtype Date
   = Date (MixedIntegral '[KinBound, UinalBound, TunBound, KatunBound] 'False)
   deriving stock (Eq, Ord, Show)
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = Mayan.epoch
 
   -- (11.3)
   fromFixed rd = Date . safeInterpret . offset $ rd - Mayan.epoch
   fromMoment (Moment t) = fromFixed . RD $ floor t
 
-instance Calendar Date where
+instance LinearCalendar Date where
   -- (11.2)
   fixedFrom (Date d) = Mayan.epoch + RD (eval d)
 

--- a/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
@@ -38,7 +38,7 @@ import "fin" Data.Type.Nat qualified as Nat
 import "numeric-tangle" Numeric.Chop (floor)
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
-  ( CyclicCalendar,
+  ( Calendar,
     FixedDate (RD),
     Moment (Moment),
     epoch,
@@ -167,7 +167,7 @@ ordinal Date {number, name} =
    in widen . Haab.finMod @(Nat.FromGHC 260) $
         signedNumber - 1 + 39 * (signedNumber - widen (fromEnum name))
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   -- (11.8)
   epoch _ = Mayan.epoch - RD (widen . ordinal $ Date 4 Ahau)
 

--- a/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
@@ -14,7 +14,6 @@ module Data.Calendar.Mayan.Tzolkin
     Number,
     name,
     number,
-    onOrBefore,
     ordinal,
     roundOnOrBefore,
     yearBearerFromFixed,
@@ -39,6 +38,7 @@ import "numeric-tangle" Numeric.Chop (floor)
 import "numeric-tangle" Numeric.Widen (widen)
 import "this" Data.Calendar
   ( Calendar,
+    CyclicCalendar,
     FixedDate (RD),
     Moment (Moment),
     epoch,
@@ -46,6 +46,7 @@ import "this" Data.Calendar
     fromFixed,
     fromMoment,
     offset,
+    onOrBefore,
   )
 import "this" Data.Calendar.Mayan qualified as Mayan
 import "this" Data.Calendar.Mayan.Haab qualified as Haab
@@ -195,11 +196,11 @@ instance Calendar Date where
 -- | Mayan tzolkin date of fixed @date@.
 --
 --  (11.11)
-onOrBefore :: Date -> FixedDate -> FixedDate
-onOrBefore tzolkin (RD date) =
-  RD $
-    (widen (ordinal tzolkin) + offset (epoch (Proxy :: Proxy Date)))
-      `modI` (date, date - 260)
+instance CyclicCalendar Date where
+  onOrBefore tzolkin (RD date) =
+    RD $
+      (widen (ordinal tzolkin) + offset (epoch (Proxy :: Proxy Date)))
+        `modI` (date, date - 260)
 
 -- | Year bearer of year containing fixed @date@. Returns `Nothing` for uayeb.
 --
@@ -208,7 +209,7 @@ yearBearerFromFixed :: FixedDate -> Maybe Name
 yearBearerFromFixed date =
   if Haab.month (fromFixed date) == Haab.Uayeb
     then empty
-    else pure . name . fromFixed $ Haab.onOrBefore (Haab.Date Haab.Pop 0) date
+    else pure . name . fromFixed $ Haab.Date Haab.Pop 0 `onOrBefore` date
 
 -- | Fixed date of latest date on or before @date@, that is Mayan haab date
 --   @haab@ and tzolkin date @tzolkin@. Returns `Nothing` for impossible

--- a/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
@@ -54,8 +54,8 @@ import "this" Data.Calendar.Types
   ( Integer,
     ModularEnum,
     NonnegativeInteger,
+    amod,
     mod,
-    mod1,
     modI,
     modularToEnum,
     toModularEnum,
@@ -176,7 +176,7 @@ instance Calendar Date where
   fromFixed date =
     let
      in Date
-          { number = fromIntegral (count `mod1` 13),
+          { number = fromIntegral (count `amod` 13),
             name = toModularEnum count
           }
     where

--- a/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
@@ -56,7 +56,7 @@ import "this" Data.Calendar.Types
     NonnegativeInteger,
     amod,
     mod,
-    modI,
+    mod3,
     modularToEnum,
     toModularEnum,
   )
@@ -200,7 +200,7 @@ instance CyclicCalendar Date where
   onOrBefore tzolkin (RD date) =
     RD $
       (widen (ordinal tzolkin) + offset (epoch (Proxy :: Proxy Date)))
-        `modI` (date, date - 260)
+        `mod3` (date, date - 260)
 
 -- | Year bearer of year containing fixed @date@. Returns `Nothing` for uayeb.
 --
@@ -219,7 +219,7 @@ yearBearerFromFixed date =
 roundOnOrBefore :: Haab.Date -> Date -> FixedDate -> Maybe FixedDate
 roundOnOrBefore haab tzolkin (RD date) =
   if (diff `mod` 5) == 0
-    then pure . RD $ (haabCount + 365 * diff) `modI` (date, date - 18_980)
+    then pure . RD $ (haabCount + 365 * diff) `mod3` (date, date - 18_980)
     else empty -- haab-tzolkin combination is impossible.
   where
     haabCount =

--- a/calendrical/src/Data/Calendar/Types.hs
+++ b/calendrical/src/Data/Calendar/Types.hs
@@ -48,7 +48,7 @@ module Data.Calendar.Types
     mins,
     mn,
     mod,
-    modI,
+    mod3,
     modularToEnum,
     next,
     poly,
@@ -236,8 +236,13 @@ amod x y = y + x `mod` (-y)
 --   mod = Prelude.mod
 
 -- | The value of @x@ shifted into the range [@a@..@b@). Returns @x@ if @a=b@.
-modI :: (Eq a, Mod a) => a -> (a, a) -> a
-modI x (a, b) = if a == b then x else a + (x - a) `mod` (b - a)
+--
+--  __NOTE__: This is generalized from the Common Lisp version, because it
+--            accepts anything that implements `Mod`. It also takes a tuple as
+--            its second argument rather than taking three arguments, so it can
+--            be used as an operator.
+mod3 :: (Eq a, Mod a) => a -> (a, a) -> a
+mod3 x (a, b) = if a == b then x else a + (x - a) `mod` (b - a)
 
 -- | [0..360)
 type Angle :: Type

--- a/calendrical/src/Data/Calendar/Types.hs
+++ b/calendrical/src/Data/Calendar/Types.hs
@@ -231,8 +231,9 @@ amod x y = y + x `mod` (-y)
 -- instance Mod Natural where
 --   mod = Prelude.mod
 
+-- | The value of @x@ shifted into the range [@a@..@b@). Returns @x@ if @a=b@.
 modI :: (Eq a, Mod a) => a -> (a, a) -> a
-modI x (a, b) = if a == b then x else a + (x - a `mod` b - a)
+modI x (a, b) = if a == b then x else a + (x - a) `mod` (b - a)
 
 mod1 :: (Eq a, Mod a) => a -> a -> a
 mod1 x b = let r = x `mod` b in if r == 0 then b else r

--- a/calendrical/src/Data/Calendar/Types.hs
+++ b/calendrical/src/Data/Calendar/Types.hs
@@ -82,7 +82,6 @@ import "base" Data.Monoid (Sum (Sum), getSum)
 import "base" Data.Ord ((<=))
 import "base" Data.Proxy (Proxy (Proxy))
 import "base" Data.Ratio (Ratio, Rational)
-import "base" Data.Tuple (fst)
 import "base" Numeric (asin, atan, cos, pi, sin, tan)
 import "base" Numeric.Natural (Natural)
 import "fin" Data.Fin (Fin)
@@ -90,7 +89,7 @@ import "fin" Data.Type.Nat (Nat)
 import "fin" Data.Type.Nat qualified as Nat
 import "mixed-radix" Numeric.MixedRadix (MixedRadix)
 import "mixed-radix" Numeric.MixedRadix qualified as Mixed
-import "numeric-tangle" Numeric.Chop (ceiling, floor, mixedFraction)
+import "numeric-tangle" Numeric.Chop (ceiling, floor)
 import "numeric-tangle" Numeric.Ration (rationalize, (%))
 import "numeric-tangle" Numeric.Widen (widen)
 import "base" Prelude
@@ -221,7 +220,7 @@ bogus = error "bogus"
 
 -- | Whole part of @m@/@n@.
 quotient :: Real -> NonzeroReal -> Integer
-quotient m = fst . mixedFraction . (m %)
+quotient m = floor . (m %)
 
 -- | The value of (@x@ mod @y@) with @y@ instead of 0.
 --

--- a/calendrical/src/Data/Calendar/Types.hs
+++ b/calendrical/src/Data/Calendar/Types.hs
@@ -48,7 +48,6 @@ module Data.Calendar.Types
     mins,
     mn,
     mod,
-    mod1,
     modI,
     modularToEnum,
     next,
@@ -225,7 +224,12 @@ quotient :: Real -> NonzeroReal -> Integer
 quotient m = fst . mixedFraction . (m %)
 
 -- | The value of (@x@ mod @y@) with @y@ instead of 0.
-amod :: Integer -> NonzeroInteger -> Integer
+--
+--  __NOTE__: The type has been changed from the Common Lisp implementation.
+--            It’s generalized to anything that implements `Mod` and doesn’t
+--            specify “Nonnegative” for the second argument (but that was never
+--            enforced at the type level anyway).
+amod :: (Mod a) => a -> a -> a
 amod x y = y + x `mod` (-y)
 
 -- instance Mod Natural where
@@ -234,9 +238,6 @@ amod x y = y + x `mod` (-y)
 -- | The value of @x@ shifted into the range [@a@..@b@). Returns @x@ if @a=b@.
 modI :: (Eq a, Mod a) => a -> (a, a) -> a
 modI x (a, b) = if a == b then x else a + (x - a) `mod` (b - a)
-
-mod1 :: (Eq a, Mod a) => a -> a -> a
-mod1 x b = let r = x `mod` b in if r == 0 then b else r
 
 -- | [0..360)
 type Angle :: Type

--- a/calendrical/src/Data/Calendar/Zoroastrian.hs
+++ b/calendrical/src/Data/Calendar/Zoroastrian.hs
@@ -15,8 +15,8 @@ import "base" Data.Function (($))
 import "base" Data.Kind (Type)
 import "base" Data.Ord (Ord)
 import "this" Data.Calendar
-  ( Calendar,
-    CyclicCalendar,
+  ( LinearCalendar,
+    Calendar,
     FixedDate (RD),
     epoch,
     fixedFrom,
@@ -50,10 +50,10 @@ type Date = T30P5.Date Month
 ops :: T30P5.Operations Month
 ops = T30P5.operationsForEpoch $ RD 230638
 
-instance CyclicCalendar Date where
+instance Calendar Date where
   epoch _ = T30P5.epoch ops
   fromFixed = T30P5.fromFixed ops
   fromMoment = T30P5.fromMoment ops
 
-instance Calendar Date where
+instance LinearCalendar Date where
   fixedFrom = T30P5.fixedFrom ops

--- a/calendrical/src/Data/Calendar/Zoroastrian.hs
+++ b/calendrical/src/Data/Calendar/Zoroastrian.hs
@@ -14,10 +14,12 @@ import "base" Data.Eq (Eq)
 import "base" Data.Function (($))
 import "base" Data.Kind (Type)
 import "base" Data.Ord (Ord)
+import "base" Text.Read (Read)
+import "base" Text.Show (Show)
 import "this" Data.Calendar
-  ( LinearCalendar,
-    Calendar,
+  ( Calendar,
     FixedDate (RD),
+    LinearCalendar,
     epoch,
     fixedFrom,
     fromFixed,
@@ -42,7 +44,7 @@ data Month
   | Bahman
   | Asfand
   | GathaDays
-  deriving stock (Bounded, Enum, Eq, Ord)
+  deriving stock (Bounded, Enum, Eq, Ord, Read, Show)
 
 type Date :: Type
 type Date = T30P5.Date Month

--- a/calendrical/tests/Properties/Calendars.hs
+++ b/calendrical/tests/Properties/Calendars.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: 2026 Greg Pfeil
+-- License: AGPL-3.0-only WITH Universal-FOSS-exception-1.0 OR LicenseRef-commercial
+--
+-- Per-calendar wiring for the class-generic property bundles in
+-- "Properties.Class".
+module Properties.Calendars (allCalendarTests) where
+
+import "base" Data.Eq (Eq)
+import "base" Data.Maybe (Maybe (Just, Nothing))
+import "base" Data.Proxy (Proxy (Proxy))
+import "base" Text.Show (Show)
+import "calendrical" Data.Calendar
+  ( CyclicCalendar,
+    DayOfWeek,
+    FixedDate,
+    JulianDayNumber,
+    LinearCalendar,
+    ModifiedJulianDayNumber,
+    Unix,
+    epoch,
+  )
+import "calendrical" Data.Calendar.Akan qualified as Akan
+import "calendrical" Data.Calendar.Armenian qualified as Armenian
+import "calendrical" Data.Calendar.Coptic qualified as Coptic
+import "calendrical" Data.Calendar.Egyptian qualified as Egyptian
+import "calendrical" Data.Calendar.Ethiopic qualified as Ethiopic
+import "calendrical" Data.Calendar.Gregorian qualified as Gregorian
+import "calendrical" Data.Calendar.Hindu.Old.Lunar qualified as HinduOldLunar
+import "calendrical" Data.Calendar.Hindu.Old.Solar qualified as HinduOldSolar
+import "calendrical" Data.Calendar.Icelandic qualified as Icelandic
+import "calendrical" Data.Calendar.Islamic qualified as Islamic
+import "calendrical" Data.Calendar.Iso qualified as Iso
+import "calendrical" Data.Calendar.Julian qualified as Julian
+import "calendrical" Data.Calendar.Mayan.Haab qualified as MayanHaab
+import "calendrical" Data.Calendar.Mayan.LongCount qualified as MayanLongCount
+import "calendrical" Data.Calendar.Mayan.Tzolkin qualified as MayanTzolkin
+import "calendrical" Data.Calendar.Types (NonnegativeInteger)
+import "calendrical" Data.Calendar.Zoroastrian qualified as Zoroastrian
+import "tasty" Test.Tasty (TestTree, testGroup)
+import "this" Properties.Class (calendarTests, cyclicTests, linearTests)
+import "base" Prelude (Integer, String)
+
+-- | Combine the `Calendar` and `LinearCalendar` properties for one date type.
+linearGroup ::
+  forall a.
+  (LinearCalendar a, Show a) =>
+  String ->
+  Proxy a ->
+  TestTree
+linearGroup name p =
+  testGroup name [calendarTests p, linearTests p]
+
+-- | Combine the `Calendar` and `CyclicCalendar` properties for one date type.
+cyclicGroup ::
+  forall a.
+  (CyclicCalendar a, Show a, Eq a) =>
+  String ->
+  Proxy a ->
+  Integer ->
+  Maybe (a -> NonnegativeInteger, FixedDate) ->
+  TestTree
+cyclicGroup name p len mOrd =
+  testGroup name [calendarTests p, cyclicTests p len mOrd]
+
+allCalendarTests :: TestTree
+allCalendarTests =
+  testGroup
+    "calendar invariants"
+    [ linearGroup "FixedDate" (Proxy @FixedDate),
+      linearGroup "JulianDayNumber" (Proxy @JulianDayNumber),
+      linearGroup "ModifiedJulianDayNumber" (Proxy @ModifiedJulianDayNumber),
+      linearGroup "Unix" (Proxy @Unix),
+      linearGroup "Gregorian" (Proxy @Gregorian.Date),
+      linearGroup "Julian" (Proxy @Julian.Date),
+      linearGroup "Julian.RomanDate" (Proxy @Julian.RomanDate),
+      linearGroup "Coptic" (Proxy @Coptic.Date),
+      linearGroup "Ethiopic" (Proxy @Ethiopic.Date),
+      linearGroup "Egyptian" (Proxy @Egyptian.Date),
+      linearGroup "Armenian" (Proxy @Armenian.Date),
+      linearGroup "Zoroastrian" (Proxy @Zoroastrian.Date),
+      linearGroup "Islamic" (Proxy @Islamic.Date),
+      linearGroup "Iso" (Proxy @Iso.Date),
+      linearGroup "Icelandic" (Proxy @Icelandic.Date),
+      linearGroup "Hindu.Old.Solar" (Proxy @HinduOldSolar.Date),
+      linearGroup "Hindu.Old.Lunar" (Proxy @HinduOldLunar.Date),
+      linearGroup "Mayan.LongCount" (Proxy @MayanLongCount.Date),
+      cyclicGroup "DayOfWeek" (Proxy @DayOfWeek) 7 Nothing,
+      cyclicGroup "Akan.Name" (Proxy @Akan.Name) 42 Nothing,
+      cyclicGroup
+        "Mayan.Haab"
+        (Proxy @MayanHaab.Date)
+        365
+        (Just (MayanHaab.ordinal, epoch (Proxy @MayanHaab.Date))),
+      cyclicGroup
+        "Mayan.Tzolkin"
+        (Proxy @MayanTzolkin.Date)
+        260
+        (Just (MayanTzolkin.ordinal, epoch (Proxy @MayanTzolkin.Date)))
+    ]

--- a/calendrical/tests/Properties/Class.hs
+++ b/calendrical/tests/Properties/Class.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE Trustworthy #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- |
+-- Copyright: 2026 Greg Pfeil
+-- License: AGPL-3.0-only WITH Universal-FOSS-exception-1.0 OR LicenseRef-commercial
+--
+-- Class-generic Hedgehog property bundles for the calendar classes.
+module Properties.Class
+  ( calendarTests,
+    linearTests,
+    cyclicTests,
+    genFixedDate,
+  )
+where
+
+import "base" Control.Applicative ((<*>))
+import "base" Data.Eq (Eq)
+import "base" Data.Foldable (for_)
+import "base" Data.Function (($), (.))
+import "base" Data.Functor ((<$>))
+import "base" Data.Int (Int)
+import "base" Data.List qualified as List
+import "base" Data.List.NonEmpty qualified as NonEmpty
+import "base" Data.Maybe (Maybe (Just, Nothing))
+import "base" Data.Ord ((<), (<=))
+import "base" Data.Semigroup ((<>))
+import "base" Text.Show (Show)
+import "calendrical" Data.Calendar
+  ( Calendar,
+    CyclicCalendar,
+    FixedDate (RD),
+    LinearCalendar,
+    fixedFrom,
+    fixedsFrom,
+    fromFixed,
+    offset,
+    onOrBefore,
+  )
+import "calendrical" Data.Calendar.Types (NonnegativeInteger)
+import "hedgehog" Hedgehog (Gen, assert, forAll, property, (===))
+import "hedgehog" Hedgehog.Gen qualified as Gen
+import "hedgehog" Hedgehog.Range qualified as Range
+import "tasty" Test.Tasty (TestTree, testGroup)
+import "tasty-hedgehog" Test.Tasty.Hedgehog (testProperty)
+import "base" Prelude (Integer, length, mod, toInteger, (-))
+
+-- | Generates `FixedDate`s in a wide band around @`RD` 0@ (≈ ±10⁴ years).
+--   Wide enough to cross many cycles for the cyclic calendars, narrow enough
+--   that integer arithmetic in the calendars stays well‑behaved.
+genFixedDate :: Gen FixedDate
+genFixedDate = RD <$> Gen.integral (Range.linearFrom 0 (-3_650_000) 3_650_000)
+
+-- | Window into a cycle: an offset @n@ to skip and a length @m@ to inspect.
+genWindow :: Gen (Int, Int)
+genWindow =
+  (,)
+    <$> Gen.int (Range.linear 0 100)
+    <*> Gen.int (Range.linear 1 20)
+
+-- | Properties every `Calendar` instance must satisfy: `fromFixed` is total,
+--   and every element of any prefix of `fixedsFrom d` projects back to @d@.
+calendarTests ::
+  forall a proxy.
+  (Calendar a, Show a, Eq a) =>
+  proxy a ->
+  TestTree
+calendarTests _ =
+  testGroup
+    "Calendar"
+    [ testProperty "fromFixed total ∧ fixedsFrom members project back to date" $
+        property do
+          rd <- forAll genFixedDate
+          (n, m) <- forAll genWindow
+          let d :: a
+              d = fromFixed rd
+              sample =
+                List.take m . List.drop n . NonEmpty.toList $ fixedsFrom d
+          for_ sample $ \rd' -> fromFixed rd' === d
+    ]
+
+-- | Properties every `LinearCalendar` instance must satisfy: `fromFixed` and
+--   `fixedFrom` are mutually inverse.
+linearTests ::
+  forall a proxy.
+  (LinearCalendar a, Show a) =>
+  proxy a ->
+  TestTree
+linearTests _ =
+  testGroup
+    "LinearCalendar"
+    [ testProperty "fixedFrom . fromFixed = id on FixedDate" $ property do
+        rd <- forAll genFixedDate
+        fixedFrom (fromFixed @a rd) === rd,
+      testProperty "fromFixed . fixedFrom = id on date" $ property do
+        rd <- forAll genFixedDate
+        let d = fromFixed @a rd
+        fromFixed (fixedFrom d) === d
+    ]
+
+-- | Properties every `CyclicCalendar` instance must satisfy. Caller supplies
+--   the cycle length and, optionally, an @ordinal@ function paired with the
+--   calendar’s epoch as a `FixedDate` (used to verify
+--   @ordinal d ≡ (rd − epoch) `mod` cycleLength@).
+cyclicTests ::
+  forall a proxy.
+  (CyclicCalendar a, Show a, Eq a) =>
+  proxy a ->
+  -- | cycle length
+  Integer ->
+  -- | optional @(ordinal, epoch)@
+  Maybe (a -> NonnegativeInteger, FixedDate) ->
+  TestTree
+cyclicTests _ cycleLen mOrdinal =
+  testGroup "CyclicCalendar" $
+    [ testProperty "onOrBefore d rd ≤ rd, gap < cycleLength, projects to d" $
+        property do
+          rd <- forAll genFixedDate
+          let d = fromFixed @a rd
+              rd' = d `onOrBefore` rd
+          assert (rd' <= rd)
+          assert (offset rd - offset rd' < cycleLen)
+          fromFixed rd' === d,
+      testProperty
+        "fixedsFrom prefix has requested length and is cycle-aligned"
+        $ property do
+          rd <- forAll genFixedDate
+          (n, m) <- forAll genWindow
+          let d = fromFixed @a rd
+              ne = fixedsFrom d
+              origin = NonEmpty.head ne
+              sample = List.take m . List.drop n $ NonEmpty.toList ne
+          length sample === m
+          -- Every element is at a whole-cycle offset from the origin. We don't
+          -- require the prefix to be sorted, since calendars are free to list
+          -- occurrences in any order (e.g. Mayan.Haab interleaves backward and
+          -- forward from `origin`).
+          for_ sample $ \rd' ->
+            (offset rd' - offset origin) `mod` cycleLen === 0
+    ]
+      <> case mOrdinal of
+        Nothing -> []
+        Just (ordinal, ep) ->
+          [ testProperty
+              "ordinal d ∈ [0, cycleLength) ∧ matches (rd − epoch) mod cycle"
+              $ property do
+                rd <- forAll genFixedDate
+                let d = fromFixed @a rd
+                    n = toInteger (ordinal d)
+                assert (n < cycleLen)
+                n === (offset rd - offset ep) `mod` cycleLen
+          ]

--- a/calendrical/tests/properties.hs
+++ b/calendrical/tests/properties.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE Trustworthy #-}
+
+-- |
+-- Copyright: 2026 Greg Pfeil
+-- License: AGPL-3.0-only WITH Universal-FOSS-exception-1.0 OR LicenseRef-commercial
+module Main (main) where
+
+import "base" System.IO (IO)
+import "tasty" Test.Tasty (defaultMain)
+import "this" Properties.Calendars (allCalendarTests)
+
+main :: IO ()
+main = defaultMain allCalendarTests


### PR DESCRIPTION
This catches even more bugs.

It also restructures the type class hierarchy – `Calendar` is now generic and has disjoint `CyclicCalendar` and `LinearCalendar` subclasses.