### PR TITLE
Extend `CyclicCalendar`

### DIFF
--- a/calendrical/src/Data/Calendar.hs
+++ b/calendrical/src/Data/Calendar.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-name-shadowing -Wno-unused-top-binds #-}
 -- __FIXME__: I think this is due to a GHC bug.
@@ -26,23 +25,28 @@ module Data.Calendar
     StandardMonth,
     StandardYear,
     Unix (SecondsSinceUnixEpoch),
+    after,
+    before,
     clockFromMoment,
+    cycleLength,
     epoch,
+    firstDay,
     fixedFrom,
     fixedsFrom,
     fromFixed,
     fromMoment,
     intervalClosed,
     invertAngular,
-    kdayAfter,
-    kdayBefore,
-    kdayNearest,
-    kdayOnOrAfter,
+    lastDay,
     listRange,
     momentFrom,
     momentToReal,
+    nearest,
+    nthDay,
     offset,
+    onOrAfter,
     onOrBefore,
+    ordinal,
     positionsInRange,
     timeFromClock,
     timeFromMoment,
@@ -69,7 +73,7 @@ import "base" Data.Functor.Identity (Identity (Identity))
 import "base" Data.Kind (Constraint, Type)
 import "base" Data.List.NonEmpty (NonEmpty ((:|)))
 import "base" Data.Maybe (Maybe (Just))
-import "base" Data.Ord (Ord, (<), (<=))
+import "base" Data.Ord (Ord, Ordering (EQ, GT, LT), compare, (<), (<=))
 import "base" Data.Proxy (Proxy (Proxy))
 import "base" Data.Tuple (fst, snd, uncurry)
 import "base" Numeric.Natural (Natural)
@@ -88,10 +92,13 @@ import "this" Data.Calendar.Types
     Mod,
     ModularEnum,
     NonegativeReal,
+    NonnegativeInteger,
+    NonzeroInteger,
     PositiveReal,
     Real,
     amod,
     binarySearch,
+    bogus,
     deg,
     mod,
     mod3,
@@ -106,6 +113,8 @@ import "base" Prelude
     --           a “weaker” `Enum` that gives us `prev`/`succ` without the
     --           mapping to `Int`.
     fromIntegral,
+    pred,
+    quot,
     toEnum,
     (*),
     (+),
@@ -192,10 +201,62 @@ class Calendar date where
 -- | A `Calendar` whose date space wraps around in a cycle, so a given @date@
 --   maps to infinitely many `FixedDate`s.
 type CyclicCalendar :: Type -> Constraint
-class (Calendar date) => CyclicCalendar date where
+class (Calendar date, LinearCalendar (RD date)) => CyclicCalendar date where
+  -- | Number of days in a cycle.
+  cycleLength :: proxy date -> NonnegativeInteger
+
+  -- | Number of days into the cycle.
+  --
+  --  __TODO__: Could probably have this return @`Fin` cycleLength@.
+  ordinal :: date -> NonnegativeInteger
+
   -- | The latest `FixedDate` on or before the given one whose `fromFixed`
   --   projection equals @date@.
   onOrBefore :: date -> FixedDate -> FixedDate
+  onOrBefore date (RD rd) =
+    RD $
+      (widen (ordinal date) + offset (fixedFrom $ epoch p))
+        `mod3` (rd, rd - widen (cycleLength p))
+    where
+      p :: Proxy date
+      p = Proxy
+
+onOrAfter ::
+  forall date. (CyclicCalendar date) => date -> FixedDate -> FixedDate
+onOrAfter d =
+  (d `onOrBefore`) . (+ RD (widen . pred $ cycleLength (Proxy :: Proxy date)))
+
+nearest :: forall date. (CyclicCalendar date) => date -> FixedDate -> FixedDate
+nearest d =
+  (d `onOrBefore`) . (+ RD (widen $ cycleLength (Proxy :: Proxy date) `quot` 2))
+
+-- | Fixed date of the @k@-day before fixed @date@. @k@=0 means Sunday, @k@=1
+--   means Monday, and so on.
+before :: (CyclicCalendar date) => date -> FixedDate -> FixedDate
+before d date = d `onOrBefore` (date - 1)
+
+-- | Fixed date of the @k@-day after fixed @date@. @k@=0 means Sunday, @k@=1
+--   means Monday, and so on.
+after :: forall date. (CyclicCalendar date) => date -> FixedDate -> FixedDate
+after d = (d `onOrBefore`) . (+ RD (widen $ cycleLength (Proxy :: Proxy date)))
+
+-- | If @n@>0, return the @n@-th @k@-day on or after @gDate@. If @n@<0, return
+--   the @n@-th @k@-day on or before @gDate@. If @n@=0 return bogus.
+--
+--  __NOTE__: This is generalized from @nth-kday@.
+nthDay ::
+  (CyclicCalendar date) => NonzeroInteger -> date -> FixedDate -> FixedDate
+nthDay n d =
+  RD
+    . (widen (cycleLength $ Identity d) * n +)
+    . offset
+    . (case compare n 0 of GT -> before; LT -> after; EQ -> bogus) d
+
+firstDay :: (CyclicCalendar date) => date -> FixedDate -> FixedDate
+firstDay = nthDay 1
+
+lastDay :: (CyclicCalendar date) => date -> FixedDate -> FixedDate
+lastDay = nthDay (-1)
 
 -- |
 --
@@ -438,28 +499,8 @@ type StandardYear :: Type
 type StandardYear = Integer
 
 instance CyclicCalendar DayOfWeek where
-  -- Fixed date of the @k@-day on or before fixed @date@.
-  onOrBefore k (RD date) =
-    RD $
-      date
-        - widen
-          (fromEnum @DayOfWeek . fromFixed . RD $ date - widen (fromEnum k))
-
-kdayOnOrAfter :: DayOfWeek -> FixedDate -> FixedDate
-kdayOnOrAfter k = onOrBefore k . (+ 6)
-
-kdayNearest :: DayOfWeek -> FixedDate -> FixedDate
-kdayNearest k = onOrBefore k . (+ 3)
-
--- | Fixed date of the @k@-day before fixed @date@. @k@=0 means Sunday, @k@=1
---   means Monday, and so on.
-kdayBefore :: DayOfWeek -> FixedDate -> FixedDate
-kdayBefore k date = onOrBefore k $ date - 1
-
--- | Fixed date of the @k@-day after fixed @date@. @k@=0 means Sunday, @k@=1
---   means Monday, and so on.
-kdayAfter :: DayOfWeek -> FixedDate -> FixedDate
-kdayAfter k = onOrBefore k . (+ 7)
+  cycleLength _ = 7
+  ordinal = fromIntegral . fromEnum
 
 -- instance Calendar FrenchRevolutionary where
 --   epoch _ = RD 654415

--- a/calendrical/src/Data/Calendar/Akan.hs
+++ b/calendrical/src/Data/Calendar/Akan.hs
@@ -31,13 +31,14 @@ import "this" Data.Calendar
     FixedDate (RD),
     Moment (Moment),
     amod,
+    cycleLength,
     epoch,
     fixedsFrom,
     fromFixed,
     fromMoment,
-    mod3,
     offset,
     onOrBefore,
+    ordinal,
   )
 import "this" Data.Calendar.Types (ModularEnum, modularToEnum)
 import "base" Prelude
@@ -125,7 +126,8 @@ nameDifference :: Name -> Name -> Integer
 nameDifference day1 day2 =
   prefixDifference + 36 * (stemDifference - prefixDifference) `amod` 42
   where
-    prefixDifference = fromIntegral $ fromEnum (prefix day2) - fromEnum (prefix day1)
+    prefixDifference =
+      fromIntegral $ fromEnum (prefix day2) - fromEnum (prefix day1)
     stemDifference = fromIntegral $ fromEnum (stem day2) - fromEnum (stem day1)
 
 instance Calendar Name where
@@ -133,7 +135,7 @@ instance Calendar Name where
   fromFixed (RD date) = dayName (date - offset (epoch (Proxy :: Proxy Name)))
   fromMoment (Moment t) = fromFixed . RD $ floor t
   fixedsFrom name =
-    let origin = onOrBefore name . epoch $ Identity name
+    let origin = name `onOrBefore` epoch (Identity name)
      in origin
           :| ( ( \cycle ->
                    let days = 42 * cycle in [origin - days, origin + days]
@@ -142,6 +144,6 @@ instance Calendar Name where
              )
 
 instance CyclicCalendar Name where
-  -- Fixed date of latest date on or before fixed @date@ that has Akan @name@.
-  onOrBefore name (RD date) =
-    RD $ nameDifference (fromFixed $ RD 0) name `mod3` (date, date - 42)
+  cycleLength _ = 42
+  ordinal =
+    fromIntegral . nameDifference (fromFixed $ epoch (Proxy :: Proxy Name))

--- a/calendrical/src/Data/Calendar/Gregorian.hs
+++ b/calendrical/src/Data/Calendar/Gregorian.hs
@@ -50,7 +50,7 @@ import "base" Data.Bool (Bool (True), not, (&&), (||))
 import "base" Data.Eq (Eq, (==))
 import "base" Data.Function (($))
 import "base" Data.Kind (Type)
-import "base" Data.Ord (Ord, Ordering (EQ, GT, LT), compare, (<), (<=))
+import "base" Data.Ord (Ord, (<), (<=))
 import "base" Data.Proxy (Proxy (Proxy))
 import "base" Data.Ratio ((%))
 import "base" Data.Tuple (fst, snd, uncurry)
@@ -69,22 +69,23 @@ import "this" Data.Calendar
     Range,
     amod,
     epoch,
+    firstDay,
     fixedFrom,
     fromFixed,
     fromMoment,
-    kdayAfter,
-    kdayBefore,
-    kdayNearest,
-    kdayOnOrAfter,
+    lastDay,
     mod,
+    nearest,
+    nthDay,
     offset,
+    onOrAfter,
   )
 import "this" Data.Calendar.Types
   ( Integer,
     ModularEnum,
     NonnegativeInteger,
+    NonzeroInteger,
     PositiveInteger,
-    bogus,
     modularToEnum,
   )
 import "base" Prelude
@@ -243,21 +244,20 @@ independenceDay :: Year -> FixedDate
 independenceDay gYear = fixedFrom $ Date gYear July 4
 
 -- | If @n@>0, return the @n@-th @k@-day on or after @gDate@. If @n@<0, return
---   the @n@-th @k@-day on or before @gDate@. If @n@=0 return bogus. A @k@-day
---   of 0 means Sunday, 1 means Monday, and so on.
-nthKday :: Integer -> DayOfWeek -> Date -> FixedDate
-nthKday n k gDate = RD $ case compare n 0 of
-  GT -> 7 * n + offset (kdayBefore k fixedDate)
-  LT -> 7 * n + offset (kdayAfter k fixedDate)
-  EQ -> bogus
-  where
-    fixedDate = fixedFrom gDate
+--   the @n@-th @k@-day on or before @gDate@. If @n@=0 return bogus.
+--
+--  __NOTE__: The book has the first argument as `Integer`, but this fails on 0,
+--            so …
+nthKday :: NonzeroInteger -> DayOfWeek -> Date -> FixedDate
+nthKday n k = nthDay n k . fixedFrom
 
+-- | Fixed date of first @k@-day on or after Gregorian date @gDate@.
 firstKday :: DayOfWeek -> Date -> FixedDate
-firstKday = nthKday 1
+firstKday k = firstDay k . fixedFrom
 
+-- | Fixed date of last @k@-day on or before Gregorian date @gDate@.
 lastKday :: DayOfWeek -> Date -> FixedDate
-lastKday = nthKday (-1)
+lastKday k = lastDay k . fixedFrom
 
 laborDay :: Year -> FixedDate
 laborDay gYear = firstKday Monday $ Date gYear September 1
@@ -284,7 +284,7 @@ christmas :: Year -> FixedDate
 christmas gYear = fixedFrom $ Date gYear December 25
 
 advent :: Year -> FixedDate
-advent gYear = kdayNearest Sunday . fixedFrom $ Date gYear November 30
+advent gYear = Sunday `nearest` fixedFrom (Date gYear November 30)
 
 epiphany :: Year -> FixedDate
 epiphany gYear = firstKday Sunday $ Date gYear January 2
@@ -300,7 +300,7 @@ unluckyFridaysInRange a b =
     else []
   where
     range = (a, b)
-    fri = kdayOnOrAfter Friday a
+    fri = Friday `onOrAfter` a
     date = fromFixed fri
 
 unluckyFridays :: Year -> [FixedDate]

--- a/calendrical/src/Data/Calendar/Icelandic.hs
+++ b/calendrical/src/Data/Calendar/Icelandic.hs
@@ -48,9 +48,9 @@ import "this" Data.Calendar
     fixedFrom,
     fromFixed,
     fromMoment,
-    kdayOnOrAfter,
     mod,
     offset,
+    onOrAfter,
   )
 import "this" Data.Calendar.Gregorian qualified as Gregorian
 import "this" Data.Calendar.Types (Angle, Integer)
@@ -101,8 +101,9 @@ data Date = Date
 
 summer :: Year -> FixedDate
 summer iYear =
-  kdayOnOrAfter Thursday $
-    fixedFrom (Gregorian.Date (fromInteger iYear) Gregorian.April 19)
+  Thursday
+    `onOrAfter` fixedFrom
+      (Gregorian.Date (fromInteger iYear) Gregorian.April 19)
 
 winter :: Year -> FixedDate
 winter iYear = summer (iYear + 1) - 180

--- a/calendrical/src/Data/Calendar/Mayan/Haab.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Haab.hs
@@ -44,19 +44,18 @@ import "this" Data.Calendar
     CyclicCalendar,
     FixedDate (RD),
     Moment (Moment),
+    cycleLength,
     epoch,
     fixedsFrom,
     fromFixed,
     fromMoment,
     offset,
-    onOrBefore,
+    ordinal,
   )
 import "this" Data.Calendar.Mayan qualified as Mayan
 import "this" Data.Calendar.Types
   ( ModularEnum,
-    NonnegativeInteger,
     mod,
-    mod3,
     modularToEnum,
     toModularEnum,
   )
@@ -170,12 +169,6 @@ type Date :: Type
 data Date = Date {month :: Month, day :: Day}
   deriving stock (Eq, Ord, Show)
 
--- | Number of days into cycle of Mayan haab date @hDate@.
---
---  (11.4)
-ordinal :: Date -> NonnegativeInteger
-ordinal Date {month, day} = (fromIntegral (fromEnum month) - 1) * 20 + widen day
-
 -- | Convert an `Integral` value to a `Fin`, using the bound as modulus.
 --
 -- >>> finMod @(Nat.FromGHC 15) 403
@@ -217,7 +210,10 @@ instance Calendar Date where
 --
 --  (11.7)
 instance CyclicCalendar Date where
-  onOrBefore haab (RD date) =
-    RD $
-      widen (ordinal haab)
-        + offset (epoch (Proxy :: Proxy Date)) `mod3` (date, date - 365)
+  cycleLength _ = 365
+
+  -- Number of days into cycle of Mayan haab date @hDate@.
+  --
+  -- (11.4)
+  ordinal Date {month, day} =
+    (fromIntegral (fromEnum month) - 1) * 20 + widen day

--- a/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
+++ b/calendrical/src/Data/Calendar/Mayan/Tzolkin.hs
@@ -41,12 +41,14 @@ import "this" Data.Calendar
     CyclicCalendar,
     FixedDate (RD),
     Moment (Moment),
+    cycleLength,
     epoch,
     fixedsFrom,
     fromFixed,
     fromMoment,
     offset,
     onOrBefore,
+    ordinal,
   )
 import "this" Data.Calendar.Mayan qualified as Mayan
 import "this" Data.Calendar.Mayan.Haab qualified as Haab
@@ -159,15 +161,6 @@ type Date :: Type
 data Date = Date {number :: Number, name :: Name}
   deriving stock (Eq, Ord, Show)
 
--- | Number of days into Mayan tzolkin cycle of @tDate@.
---
---  (11.10)
-ordinal :: Date -> NonnegativeInteger
-ordinal Date {number, name} =
-  let signedNumber = widen @NonnegativeInteger @Integer $ widen number
-   in widen . Haab.finMod @(Nat.FromGHC 260) $
-        signedNumber - 1 + 39 * (signedNumber - widen (fromEnum name))
-
 instance Calendar Date where
   -- (11.8)
   epoch _ = Mayan.epoch - RD (widen . ordinal $ Date 4 Ahau)
@@ -197,10 +190,15 @@ instance Calendar Date where
 --
 --  (11.11)
 instance CyclicCalendar Date where
-  onOrBefore tzolkin (RD date) =
-    RD $
-      (widen (ordinal tzolkin) + offset (epoch (Proxy :: Proxy Date)))
-        `mod3` (date, date - 260)
+  cycleLength _ = 260
+
+  -- Number of days into Mayan tzolkin cycle of @tDate@.
+  --
+  -- (11.10)
+  ordinal Date {number, name} =
+    let signedNumber = widen @NonnegativeInteger @Integer $ widen number
+     in widen . Haab.finMod @(Nat.FromGHC 260) $
+          signedNumber - 1 + 39 * (signedNumber - widen (fromEnum name))
 
 -- | Year bearer of year containing fixed @date@. Returns `Nothing` for uayeb.
 --


### PR DESCRIPTION
This adds two more primitive operations to `CyciicCalendar`: `cycleLength` and `ordinal`, which then allows a default implementation of `onOrBefore`.

It also generalizes a number of previously `DayOfWeek`-specific operations to work for any `CyclicCalendar`.